### PR TITLE
Fix invalid tracking information

### DIFF
--- a/ios/dynamic/BrightcovePlayerSDK.framework/PrivacyInfo.xcprivacy
+++ b/ios/dynamic/BrightcovePlayerSDK.framework/PrivacyInfo.xcprivacy
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>NSPrivacyTracking</key>
-	<false/>
+	<true/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>

--- a/ios/static/BrightcovePlayerSDK.framework/PrivacyInfo.xcprivacy
+++ b/ios/static/BrightcovePlayerSDK.framework/PrivacyInfo.xcprivacy
@@ -22,7 +22,7 @@
 		</dict>
 	</array>
 	<key>NSPrivacyTracking</key>
-	<false/>
+	<true/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Following Apple requirements, NSPrivacyTracking must be true if NSPrivacyTrackingDomains isn‘t empty. 

This PR fixes this issue. 